### PR TITLE
minor fixes to log files

### DIFF
--- a/macsio/macsio_log.h
+++ b/macsio/macsio_log.h
@@ -32,6 +32,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
 /*!
 \defgroup MACSIO_LOG MACSIO_LOG
@@ -130,7 +131,8 @@ do{                                                                             
 \param [in] SEV Abbreviated message severity (e.g. 'Dbg1', 'Warn')
 \param [in] MSG Caller's sprintf-style message enclosed in parenthises (e.g. '("Rank %d failed",rank))'
 */
-#define MACSIO_LOG_MSG(SEV, MSG) MACSIO_LOG_MSG2(MACSIO_LOG_MainLog, MSG, MACSIO_LOG_Msg ## SEV, #SEV, errno, mpi_errno, __FILE__, __LINE__)
+#define __BASEFILE__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define MACSIO_LOG_MSG(SEV, MSG) MACSIO_LOG_MSG2(MACSIO_LOG_MainLog, MSG, MACSIO_LOG_Msg ## SEV, #SEV, errno, mpi_errno, __BASEFILE__, __LINE__)
 
 /*!
 \def MACSIO_LOG_MSGV
@@ -160,7 +162,7 @@ do                                                                   \
 \param [in] SEV Abbreviated message severity (e.g. 'Dbg1', 'Warn')
 \param [in] MSG Caller's sprintf-style message enclosed in parenthises (e.g. '("Rank %d failed",rank))'
 */
-#define MACSIO_LOG_MSGL(LOG, SEV, MSG) MACSIO_LOG_MSG2(LOG, MSG, MACSIO_LOG_Msg ## SEV, #SEV, errno, mpi_errno, __FILE__, __LINE__)
+#define MACSIO_LOG_MSGL(LOG, SEV, MSG) MACSIO_LOG_MSG2(LOG, MSG, MACSIO_LOG_Msg ## SEV, #SEV, errno, mpi_errno, __BASEFILE__, __LINE__)
 
 /*!
 \def MACSIO_LOG_MSGLV

--- a/macsio/macsio_main.c
+++ b/macsio/macsio_main.c
@@ -493,7 +493,8 @@ write_timings_file(char const *filename)
     MPI_Allreduce(rdata, rdata_out, 3, MPI_INT, MPI_MAX, MACSIO_MAIN_Comm);
 #endif
 
-    timing_log = MACSIO_LOG_LogInit(MACSIO_MAIN_Comm, filename, rdata_out[0], rdata_out[1], rdata_out[2]+1);
+    /* add 32 chars to line len for log leader */
+    timing_log = MACSIO_LOG_LogInit(MACSIO_MAIN_Comm, filename, rdata_out[0]+32, rdata_out[1], rdata_out[2]+1);
 
     /* dump this processor's timers */
     for (i = 0; i < ntimers; i++)

--- a/macsio/macsio_timing.c
+++ b/macsio/macsio_timing.c
@@ -517,13 +517,10 @@ MACSIO_TIMING_ReduceTimers(
 
     if (root == -1)
     {
-        if (timerinfo_reduce_op != NULL)
-        {
-            MPI_Op_free(&timerinfo_reduce_op);
-            MPI_Type_free(&str_32_mpi_type);
-            MPI_Type_free(&str_64_mpi_type);
-            MPI_Type_free(&timerinfo_mpi_type);
-        }
+        MPI_Op_free(&timerinfo_reduce_op);
+        MPI_Type_free(&str_32_mpi_type);
+        MPI_Type_free(&str_64_mpi_type);
+        MPI_Type_free(&timerinfo_mpi_type);
         first = 1;
         return;
     }

--- a/macsio/macsio_timing.h
+++ b/macsio/macsio_timing.h
@@ -30,6 +30,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <mpi.h>
 
 #include <stdio.h>
+#include <string.h>
 
 /*!
 \defgroup MACSIO_TIMING MACSIO_TIMING
@@ -133,7 +134,8 @@ of the timer explicitly.
 \param [in] GMASK User defined group mask. Use MACSIO_TIMING_NO_GROUP if timer grouping is not needed.
 \param [in] ITER The iteration number. Use MACSIO_TIMING_ITER_IGNORE if timer iteration is not needed.
 */
-#define MT_StartTimer(LAB, GMASK, ITER) MACSIO_TIMING_StartTimer(LAB, GMASK, ITER, __FILE__, __LINE__)
+#define __BASEFILE__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define MT_StartTimer(LAB, GMASK, ITER) MACSIO_TIMING_StartTimer(LAB, GMASK, ITER, __BASEFILE__, __LINE__)
 
 /*!
 \def MT_StopTimer
@@ -212,6 +214,24 @@ MACSIO_TIMING_GetReducedTimer(
 This call will find all used timers in the hash table matching the specified \c gmask group mask and dumps
 each timer to a string. For convenience, the maximum length of the strings is also returned. This is to
 facilitate dumping the strings to a MACSIO_LOG.
+
+Each timer is dumped to a string with the following informational fields catenated together ...
+
+  - TOT=%10.5f total amount of time spent in this time over all iterations (and ranks when reduced)
+  - CNT=%04d total number of iterations this timer was triggered (over all ranks when reduced)
+  - MIN=%8.5f(%4.2f):%06d
+    - minimum time recorded for this timer over all iterations (and ranks when reduced)
+    - (%4.2f) the number of standard deviations from the mean time
+    - :%06d the rank (when reduced) where the minimum was observed.
+  - AVG=%8.5f the mean time of this timer over all iterations (and ranks when reduced)
+  - MAX=%8.5f(%4.2f):%06d,
+    - maximum time recorded for this timer over all iterations (and ranks when reduced)
+    - (%4.2f) the number of standard deviations from the mean time
+    - :%06d the rank (when reduced) where the maximum was observed.
+  - DEV=%8.8f standard deviation observed for all iterations of this timer
+  - FILE=%s the source file where this timer is triggered
+  - LINE=%d the source line number where this timer is triggered
+  - LAB=%s the user-defined label for this timer
 */
 extern void MACSIO_TIMING_DumpTimersToStrings(
     MACSIO_TIMING_GroupMask_t gmask, /**< Group mask to filter only timers belonging to specific groups */


### PR DESCRIPTION
- use strchr to trim path from __FILE__ in log messages
- account for log leader chars in computing line length for timings-log
- fix compiler warning regarding testing of MPI_Op type against NULL
